### PR TITLE
Changed visibility criteria for ip-restrictions menu item.

### DIFF
--- a/src/controllers/ClientController.php
+++ b/src/controllers/ClientController.php
@@ -239,6 +239,7 @@ class ClientController extends \hipanel\base\CrudController
             ],
             'ip-restrictions' => [
                 'class' => ClassValuesAction::class,
+                'setApiCommand' => 'set-allowed-ips',
                 'valuesClass' => 'client,access',
                 'view' => '_ipRestrictionsModal',
             ],

--- a/src/menus/ClientDetailMenu.php
+++ b/src/menus/ClientDetailMenu.php
@@ -97,7 +97,7 @@ class ClientDetailMenu extends \hipanel\menus\AbstractDetailMenu
                     'scenario' => 'ip-restrictions',
                 ]),
                 'encode' => false,
-                'visible' => $user->is($this->model->id),
+                'visible' => $user->is($this->model->id) || $user->can('client.set-others-allowed-ips'),
             ],
             [
                 'label' => SettingsModal::widget([

--- a/src/menus/ClientDetailMenu.php
+++ b/src/menus/ClientDetailMenu.php
@@ -122,7 +122,7 @@ class ClientDetailMenu extends \hipanel\menus\AbstractDetailMenu
                 'icon' => 'fa-edit fa-fw',
                 'url' => ['@client/update', 'id' => $this->model->id],
                 'encode' => false,
-                'visible' => Yii::$app->user->can('manage'),
+                'visible' => $user->can('manage'),
             ],
             [
                 'label' => SettingsModal::widget([


### PR DESCRIPTION
For now ip-restrictions menu item is visible not only on self
profile page, but also on other others profile pages for users
who have 'client.set-others-allowed-ips' rights.

trello card: https://trello.com/c/G0g6sdwt