### PR TITLE
HP-1799: allow edit clients of same seller

### DIFF
--- a/src/models/Client.php
+++ b/src/models/Client.php
@@ -68,7 +68,7 @@ class Client extends \hipanel\base\Model implements TaggableInterface
     public function rules()
     {
         return [
-            [['id', 'seller_id', 'state_id', 'type_id', 'tariff_id', 'profile_id', 'payment_ticket_id', 'referer_id'], 'integer'],
+            [['id', 'seller_id', 'state_id', 'type_id', 'tariff_id', 'profile_id', 'payment_ticket_id', 'referer_id', 'account_owner_id'], 'integer'],
             [['hipanel_forced'], 'boolean', 'trueValue' => 1],
             [['login', 'seller', 'state', 'type', 'tariff', 'profile', 'referer'], 'string'],
             [['state_label', 'type_label', 'referral', 'roles', 'debt_label'], 'safe'],

--- a/src/models/Client.php
+++ b/src/models/Client.php
@@ -578,7 +578,7 @@ class Client extends \hipanel\base\Model implements TaggableInterface
 
     public function isAccountOwner(): bool
     {
-        return (string) $this->id !== (string) $this->account_owner_id;
+        return (string) $this->id === (string) $this->account_owner_id;
     }
 
     public function getCustomAttributesList()

--- a/src/models/Client.php
+++ b/src/models/Client.php
@@ -69,7 +69,7 @@ class Client extends \hipanel\base\Model implements TaggableInterface
     {
         return [
             [['id', 'seller_id', 'state_id', 'type_id', 'tariff_id', 'profile_id', 'payment_ticket_id', 'referer_id'], 'integer'],
-            [['hipanel_forced', 'can_be_account_owner'], 'boolean', 'trueValue' => 1],
+            [['hipanel_forced'], 'boolean', 'trueValue' => 1],
             [['login', 'seller', 'state', 'type', 'tariff', 'profile', 'referer'], 'string'],
             [['state_label', 'type_label', 'referral', 'roles', 'debt_label'], 'safe'],
 

--- a/src/models/Client.php
+++ b/src/models/Client.php
@@ -576,9 +576,9 @@ class Client extends \hipanel\base\Model implements TaggableInterface
         return (string)$this->id !== (string)Yii::$app->user->identity->seller_id;
     }
 
-    public function canBeAccountOwner(): bool
+    public function isAccountOwner(): bool
     {
-        return (bool) $this->can_be_account_owner;
+        return (string) $this->id !== (string) $this->account_owner_id;
     }
 
     public function getCustomAttributesList()

--- a/src/models/Client.php
+++ b/src/models/Client.php
@@ -69,7 +69,7 @@ class Client extends \hipanel\base\Model implements TaggableInterface
     {
         return [
             [['id', 'seller_id', 'state_id', 'type_id', 'tariff_id', 'profile_id', 'payment_ticket_id', 'referer_id'], 'integer'],
-            [['hipanel_forced'], 'boolean', 'trueValue' => 1],
+            [['hipanel_forced', 'can_be_account_owner'], 'boolean', 'trueValue' => 1],
             [['login', 'seller', 'state', 'type', 'tariff', 'profile', 'referer'], 'string'],
             [['state_label', 'type_label', 'referral', 'roles', 'debt_label'], 'safe'],
 
@@ -574,6 +574,11 @@ class Client extends \hipanel\base\Model implements TaggableInterface
     public function notMySeller(): bool
     {
         return (string)$this->id !== (string)Yii::$app->user->identity->seller_id;
+    }
+
+    public function canBeAccountOwner(): bool
+    {
+        return (bool) $this->can_be_account_owner;
     }
 
     public function getCustomAttributesList()

--- a/src/models/Client.php
+++ b/src/models/Client.php
@@ -573,7 +573,7 @@ class Client extends \hipanel\base\Model implements TaggableInterface
 
     public function notMySeller(): bool
     {
-        return (string)$this->seller_id !== (string)Yii::$app->user->identity->seller_id;
+        return (string)$this->id !== (string)Yii::$app->user->identity->seller_id;
     }
 
     public function getCustomAttributesList()

--- a/src/views/client/_form.php
+++ b/src/views/client/_form.php
@@ -111,7 +111,7 @@ $form = ActiveForm::begin([
                             </div>
                         <?php endif ?>
                     </div>
-                    <?php if (Yii::$app->user->can('purse.update')): ?>
+                    <?php if (Yii::$app->user->can('purse.update') && $this->canBeAccountOwner()): ?>
                         <div class="row">
                             <?= $form->field($model, "[{$i}]currencies")->widget(StaticCombo::class, [
                                 'multiple' => true,

--- a/src/views/client/_form.php
+++ b/src/views/client/_form.php
@@ -111,7 +111,7 @@ $form = ActiveForm::begin([
                             </div>
                         <?php endif ?>
                     </div>
-                    <?php if (Yii::$app->user->can('purse.update') && $this->canBeAccountOwner()): ?>
+                    <?php if (Yii::$app->user->can('purse.update') && $this->isAccountOwner()): ?>
                         <div class="row">
                             <?= $form->field($model, "[{$i}]currencies")->widget(StaticCombo::class, [
                                 'multiple' => true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability for clients to be marked as potential account owners.
- **Bug Fixes**
	- Corrected an issue in client identification by ensuring proper ID comparison.
- **Enhancements**
	- Improved user permission checks to conditionally display form fields based on the client's potential to be an account owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->