### PR TITLE
HP-1801: when use Nope set restriction in Nope Auth service

### DIFF
--- a/src/views/client/_ipRestrictionsModal.php
+++ b/src/views/client/_ipRestrictionsModal.php
@@ -21,7 +21,7 @@ use yii\helpers\Url;
 ]) ?>
 
     <?= Html::activeHiddenInput($model, "[$model->id]id") ?>
-    <?= $form->field($model, "[$model->id]allowed_ips") ?>
+    <?= $form->field($model, "[$model->id]allowed_ips")->textInput(['readonly' => isset(Yii::$app->params['nope.site'])]) ?>
     <?= $form->field($model, "[$model->id]sshftp_ips")->hint(Yii::t('hipanel:client', "All of accounts in the hosting panel will use following permit IP addresses list by default. You can reassign permitted IP addresses for each account individually in it's settings.")) ?>
 
     <hr>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Modified the IP Restrictions modal to make the `allowed_ips` field read-only under certain conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->