### PR TITLE
HP-2261: permit/forbid merchant payment permission

### DIFF
--- a/src/actions/ChangePaymentStatusAction.php
+++ b/src/actions/ChangePaymentStatusAction.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace hipanel\modules\client\actions;
+
+use hipanel\actions\RedirectAction;
+use hipanel\actions\SmartUpdateAction;
+
+class ChangePaymentStatusAction extends SmartUpdateAction
+{
+    public function init(): void
+    {
+        parent::init();
+        $this->_items['POST html']['error'] = [
+            'class' => RedirectAction::class,
+            'url' => static fn($action) => $action->collection->count() > 1 ?
+                $action->controller->getSearchUrl() :
+                $action->controller->getActionUrl('view', ['id' => $action->collection->first->id]),
+        ];
+    }
+}

--- a/src/forms/ChangePaymentStatusForm.php
+++ b/src/forms/ChangePaymentStatusForm.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace hipanel\modules\client\forms;
+
+use hipanel\modules\client\models\Client;
+
+class ChangePaymentStatusForm extends Client
+{
+    public bool $deny_deposit = true;
+
+    public static function tableName(): string
+    {
+        return 'client';
+    }
+
+    public function rules(): array
+    {
+        return array_merge(parent::rules(), [
+            [['deny_deposit'], 'boolean', 'on' => 'change-payment-status'],
+            [['id', 'deny_deposit'], 'required', 'on' => 'change-payment-status'],
+        ]);
+    }
+}

--- a/src/menus/ClientDetailMenu.php
+++ b/src/menus/ClientDetailMenu.php
@@ -67,9 +67,13 @@ class ClientDetailMenu extends \hipanel\menus\AbstractDetailMenu
                 'visible' => $user->is($this->model->id),
             ],
             [
-                'label' => $totp_enabled ? Yii::t('hipanel:client', 'Disable two factor authorization') : Yii::t('hipanel:client', 'Enable two factor authorization'),
+                'label' => $totp_enabled ? Yii::t('hipanel:client', 'Disable two factor authorization') : Yii::t('hipanel:client',
+                    'Enable two factor authorization'),
                 'icon' => 'fa-lock',
-                'url' => Yii::getAlias('@HIAM_SITE', false) . Url::to(['/mfa/totp/' . ($totp_enabled ? 'disable' : 'enable'), 'back' => Url::to('', true)]),
+                'url' => Yii::getAlias('@HIAM_SITE', false) . Url::to([
+                        '/mfa/totp/' . ($totp_enabled ? 'disable' : 'enable'),
+                        'back' => Url::to('', true),
+                    ]),
                 'visible' => $user->is($this->model->id),
             ],
             [
@@ -82,9 +86,9 @@ class ClientDetailMenu extends \hipanel\menus\AbstractDetailMenu
                 ]),
                 'encode' => false,
                 'visible' => $user->not($this->model->id)
-                                && $user->can('client.set-tmp-pwd')
-                                && !$this->model->isDeleted()
-                                && $this->model->type === 'client',
+                    && $user->can('client.set-tmp-pwd')
+                    && !$this->model->isDeleted()
+                    && $this->model->type === 'client',
             ],
             [
                 'label' => ImpersonateButton::widget(['model' => $this->model]),
@@ -237,12 +241,33 @@ class ClientDetailMenu extends \hipanel\menus\AbstractDetailMenu
             ] : [],
             [
                 'label' => AjaxModal::widget([
-                    'actionUrl' => ['@client/set-attributes', 'id'=> $this->model->id],
-                    'header' => Html::tag('h4', Yii::t('hipanel:client', 'Additional information'), ['class' => 'model-title']),
+                    'actionUrl' => ['@client/set-attributes', 'id' => $this->model->id],
+                    'header' => Html::tag('h4', Yii::t('hipanel:client', 'Additional information'), ['class' => 'modal-title']),
                     'scenario' => 'update',
                     'toggleButton' => [
                         'tag' => 'a',
-                        'label' => FontIcon::i('fa-edit fa-fw') . " " . Yii::t('hipanel:client', 'Set additional information'),
+                        'label' => FontIcon::i('fa-edit fa-fw') . Yii::t('hipanel:client', 'Set additional information'),
+                        'class' => 'clickable',
+                    ],
+                ]),
+                'encode' => false,
+                'visible' => $user->can('client.update'),
+            ],
+            [
+                'label' => AjaxModal::widget([
+                    'actionUrl' => ['@client/merchant-payment', 'id' => $this->model->id],
+                    'header' => Html::tag('h4', Yii::t('hipanel:client', 'Merchant payment status'), ['class' => 'modal-title']),
+                    'size' => Modal::SIZE_SMALL,
+                    'scenario' => 'change-payment-status',
+                    'toggleButton' => [
+                        'tag' => 'a',
+                        'label' => implode('', [
+                            Html::tag('i', null, ['class' => 'fa fa-fw fa-credit-card-alt']),
+                            Yii::t('hipanel:client', 'Change merchant payment status'),
+                            in_array('deny:deposit', explode(',', $this->model->roles)) ?
+                                Html::tag('span', Yii::t('hipanel:client', 'Forbidden'), ['class' => 'badge bg-red pull-right']) :
+                                Html::tag('span', Yii::t('hipanel:client', 'Permitted'), ['class' => 'badge bg-green pull-right']),
+                        ]),
                         'class' => 'clickable',
                     ],
                 ]),

--- a/src/views/client/modals/merchant-payment.php
+++ b/src/views/client/modals/merchant-payment.php
@@ -1,0 +1,26 @@
+<?php
+
+use hipanel\modules\client\forms\ChangePaymentStatusForm;
+use yii\bootstrap\ActiveForm;
+use yii\bootstrap\Html;
+
+/**
+ * @var ChangePaymentStatusForm $model
+ * @var ChangePaymentStatusForm[] $models
+ */
+
+?>
+
+<?php $form = ActiveForm::begin(['id' => 'payment-status-form']); ?>
+
+<?= Html::activeHiddenInput($model, 'id') ?>
+
+<?php if (in_array('deny:deposit', explode(',', $model->roles))) : ?>
+    <?= Html::activeHiddenInput($model, 'deny_deposit', ['value' => false]) ?>
+    <?= Html::submitButton(Yii::t('hipanel:client', 'Permit merchant payments'), ['class' => 'btn btn-success btn-block']) ?>
+<?php else : ?>
+    <?= Html::activeHiddenInput($model, 'deny_deposit', ['value' => true]) ?>
+    <?= Html::submitButton(Yii::t('hipanel:client', 'Forbid merchant payments'), ['class' => 'btn btn-danger btn-block']) ?>
+<?php endif ?>
+
+<?php ActiveForm::end() ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added merchant payment status management functionality
  - Introduced ability to permit or forbid merchant payments for clients

- **Improvements**
  - Enhanced client controller permissions
  - Updated client detail menu with new payment status toggle option

- **User Interface**
  - Added new modal for changing merchant payment status
  - Implemented dynamic payment status controls based on user roles

The update provides more granular control over client payment settings, allowing administrators to manage merchant payment permissions with greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->