### PR TITLE
HQD-157: Pincode visibility test fails: security question option not found in dropdown

### DIFF
--- a/tests/playwright/e2e/admin/pincode/pincode-visibility.spec.ts
+++ b/tests/playwright/e2e/admin/pincode/pincode-visibility.spec.ts
@@ -84,7 +84,7 @@ test.describe("Pincode Visibility Tests", () => {
     const questions = [
       "What was your nickname when you were a child?",
       "What was the name of your best childhood friend?",
-      "What is the month and the year of birth of your oldest relative?",
+      "What are the month and the year of birth of your oldest relative? (e.g. January, 1900)",
       "What is your grandmother’s maiden name?",
       "What is the patronymic of your oldest relative?",
       "Own question",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated security question label validation to reflect new format guidance "(e.g. January, 1900)" for the oldest relative field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiqdev/hipanel-module-client/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->